### PR TITLE
プレイヤーが即抜けすると切断メッセージが出ないバグの修正 +α

### DIFF
--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.event.*;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import work.novablog.mcplugin.discordconnect.DiscordConnect;
 import work.novablog.mcplugin.discordconnect.util.ConfigManager;
 import work.novablog.mcplugin.discordconnect.util.ConvertUtil;
@@ -55,12 +56,11 @@ public class BungeeListener implements Listener {
         LunaChatAPI lunaChatAPI = DiscordConnect.getInstance().getLunaChatAPI();
         if ((chatCasterApi == null || !chatCasterApi.isEnabledChatCaster()) && lunaChatAPI == null) {
             // 連携プラグインが無効の場合
-            String senderServer = ((ProxiedPlayer)event.getSender()).getServer().getInfo().getName();
-            if(hiddenServers.contains(senderServer)) senderServer = dummyServerName;
             String name = fromMinecraftToDiscordName
                     .replace("{name}", ((ProxiedPlayer) event.getSender()).getName())
                     .replace("{displayName}", ((ProxiedPlayer)event.getSender()).getDisplayName())
-                    .replace("{server}", senderServer);
+                    .replace("{server}", replaceServerDisplayName(((ProxiedPlayer)event.getSender()).getServer()).orElse("unknown"));
+
             String avatarURL = ConvertUtil.getMinecraftAvatarURL(((ProxiedPlayer) event.getSender()).getUniqueId());
 
             MarkComponent[] components = MarkdownConverter.fromMinecraftMessage(event.getMessage(), '&');
@@ -126,10 +126,7 @@ public class BungeeListener implements Listener {
         String name = fromMinecraftToDiscordName
                 .replace("{name}", e.getPlayer().getName())
                 .replace("{displayName}", e.getPlayer().getDisplayName())
-                .replace("{server}", Optional.ofNullable(e.getPlayer().getServer())
-                        .map(Server::getInfo)
-                        .map(ServerInfo::getName)
-                        .orElse("unknown"));
+                .replace("{server}", replaceServerDisplayName(e.getPlayer().getServer()).orElse("unknown"));
 
         String avatarURL = ConvertUtil.getMinecraftAvatarURL(e.getPlayer().getUniqueId());
 
@@ -173,7 +170,8 @@ public class BungeeListener implements Listener {
         String name = fromMinecraftToDiscordName
                 .replace("{name}", e.getPlayer().getName())
                 .replace("{displayName}", e.getPlayer().getDisplayName())
-                .replace("{server}", e.getPlayer().getServer().getInfo().getName());
+                .replace("{server}", replaceServerDisplayName(e.getPlayer().getServer()).orElse("unknown"));
+
         String avatarURL = ConvertUtil.getMinecraftAvatarURL(e.getPlayer().getUniqueId());
 
         WebhookEmbedBuilder webhookEmbedBuilder = new WebhookEmbedBuilder();
@@ -190,7 +188,7 @@ public class BungeeListener implements Listener {
         webhookEmbedBuilder.setDescription(
                 ConfigManager.Message.serverSwitched.toString()
                         .replace("{name}", e.getPlayer().getName())
-                        .replace("{server}", e.getPlayer().getServer().getInfo().getName())
+                        .replace("{server}", replaceServerDisplayName(e.getPlayer().getServer()).orElse("unknown"))
         );
 
         discordWebhookSenders.forEach(sender -> sender.sendMessage(
@@ -210,5 +208,17 @@ public class BungeeListener implements Listener {
                         DiscordConnect.getInstance().getProxy().getPlayers().size(),
                         DiscordConnect.getInstance().getProxy().getConfig().getPlayerLimit()
         ),1L, TimeUnit.SECONDS);
+    }
+
+    /**
+     * サーバーの表示名を返します
+     * @param server 対象のサーバー
+     * @return サーバーの表示名。無ければ {@link Optional#empty()} を返します。
+     */
+    private Optional<String> replaceServerDisplayName(@Nullable Server server) {
+        return Optional.ofNullable(server)
+                .map(Server::getInfo)
+                .map(ServerInfo::getName)
+                .map(name -> hiddenServers.contains(name) ? dummyServerName : name);
     }
 }

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
@@ -6,7 +6,9 @@ import com.github.ucchyocean.lc3.LunaChatAPI;
 import com.gmail.necnionch.myapp.markdownconverter.MarkComponent;
 import com.gmail.necnionch.myapp.markdownconverter.MarkdownConverter;
 import com.gmail.necnionch.myplugin.n8chatcaster.bungee.N8ChatCasterAPI;
+import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.*;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
@@ -20,6 +22,7 @@ import work.novablog.mcplugin.discordconnect.util.discord.DiscordWebhookSender;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class BungeeListener implements Listener {
@@ -123,7 +126,11 @@ public class BungeeListener implements Listener {
         String name = fromMinecraftToDiscordName
                 .replace("{name}", e.getPlayer().getName())
                 .replace("{displayName}", e.getPlayer().getDisplayName())
-                .replace("{server}", e.getPlayer().getServer().getInfo().getName());
+                .replace("{server}", Optional.ofNullable(e.getPlayer().getServer())
+                        .map(Server::getInfo)
+                        .map(ServerInfo::getName)
+                        .orElse("unknown"));
+
         String avatarURL = ConvertUtil.getMinecraftAvatarURL(e.getPlayer().getUniqueId());
 
         WebhookEmbedBuilder webhookEmbedBuilder = new WebhookEmbedBuilder();


### PR DESCRIPTION
### 変更点
- 接続サーバーが null の時は `unknown` サーバーになるように変更
※ プレイヤーがサーバーに接続できていない状態でプロキシから切断されると、サーバー名を取得できずNPEが発生してしまうようです。

- 非表示サーバーがダミー名にならない部分が一部あったので、replaceServerDisplayName メソッドを新たに作って対応しました。