### PR TITLE
BungeeCordコンソールログを転送する

### DIFF
--- a/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
@@ -67,7 +67,8 @@ public final class DiscordConnect extends Plugin {
      * configを読み直してbotを再起動する
      */
     public void reload() {
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 Message.serverActivity.toString(),
                 null,
                 Message.botRestarting.toString(),

--- a/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
@@ -4,6 +4,7 @@ import com.github.ucchyocean.lc3.LunaChatAPI;
 import com.github.ucchyocean.lc3.LunaChatBungee;
 import com.gmail.necnionch.myplugin.n8chatcaster.bungee.N8ChatCasterAPI;
 import com.gmail.necnionch.myplugin.n8chatcaster.bungee.N8ChatCasterPlugin;
+import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
@@ -11,6 +12,7 @@ import net.md_5.bungee.config.YamlConfiguration;
 import org.bstats.bungeecord.Metrics;
 import work.novablog.mcplugin.discordconnect.command.bungee.BungeeCommand;
 import work.novablog.mcplugin.discordconnect.listener.BungeeListener;
+import work.novablog.mcplugin.discordconnect.listener.BungeeLoggingListener;
 import work.novablog.mcplugin.discordconnect.listener.ChatCasterListener;
 import work.novablog.mcplugin.discordconnect.listener.LunaChatListener;
 import work.novablog.mcplugin.discordconnect.util.BotManager;
@@ -25,10 +27,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
+import java.util.*;
 import java.util.logging.Level;
 
 public final class DiscordConnect extends Plugin {
@@ -42,6 +42,7 @@ public final class DiscordConnect extends Plugin {
 
     private BotManager botManager;
     private BungeeListener bungeeListener;
+    private BungeeLoggingListener bungeeLoggingListener;
     private LunaChatListener lunaChatListener;
     private ChatCasterListener chatCasterListener;
 
@@ -68,7 +69,7 @@ public final class DiscordConnect extends Plugin {
      */
     public void reload() {
         botManager.sendMessageToChannel(
-                BotManager.ChannelType.CHAT,
+                BotManager.ChannelType.ALL,
                 Message.serverActivity.toString(),
                 null,
                 Message.botRestarting.toString(),
@@ -132,10 +133,26 @@ public final class DiscordConnect extends Plugin {
         String toMinecraftFormat = config.getString("toMinecraftFormat");
         String toDiscordFormat = config.getString("toDiscordFormat");
         List<String> hiddenServers = config.getStringList("hiddenServers");
+        long consoleChannelId = config.getLong("consoleChannel.channelId");
+        List<Long> consoleChannelIds = consoleChannelId == -1 ?
+                Collections.emptyList() :
+                Collections.singletonList(consoleChannelId);
+        String consoleChannelLogFormat = config.getString("consoleChannel.logFormat");
 
-        botManager = new BotManager(getLogger(), token, chatChannelIds, playingGameName, toMinecraftFormat);
+        botManager = new BotManager(
+                getLogger(),
+                token,
+                chatChannelIds,
+                consoleChannelIds,
+                playingGameName,
+                toMinecraftFormat
+        );
         bungeeListener = new BungeeListener(botManager, toDiscordFormat, hiddenServers);
         getProxy().getPluginManager().registerListener(this, bungeeListener);
+        if (!consoleChannelIds.isEmpty()) {
+            bungeeLoggingListener = new BungeeLoggingListener(botManager, consoleChannelLogFormat);
+            ProxyServer.getInstance().getLogger().addHandler(bungeeLoggingListener);
+        }
         if (lunaChatAPI != null) {
             lunaChatListener = new LunaChatListener(botManager, toDiscordFormat);
             getProxy().getPluginManager().registerListener(this, lunaChatListener);
@@ -178,6 +195,7 @@ public final class DiscordConnect extends Plugin {
 
     private void shutdown() {
         if (bungeeListener != null) getProxy().getPluginManager().unregisterListener(bungeeListener);
+        if (bungeeLoggingListener != null) ProxyServer.getInstance().getLogger().removeHandler(bungeeLoggingListener);
         if (lunaChatListener != null) getProxy().getPluginManager().unregisterListener(lunaChatListener);
         if (chatCasterListener != null) getProxy().getPluginManager().unregisterListener(chatCasterListener);
         botManager.botShutdown();

--- a/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/DiscordConnect.java
@@ -138,12 +138,14 @@ public final class DiscordConnect extends Plugin {
                 Collections.emptyList() :
                 Collections.singletonList(consoleChannelId);
         String consoleChannelLogFormat = config.getString("consoleChannel.logFormat");
+        boolean allowConsoleChannelDispatchCommand = config.getBoolean("consoleChannel.allowDispatchCommand");
 
         botManager = new BotManager(
                 getLogger(),
                 token,
                 chatChannelIds,
                 consoleChannelIds,
+                allowConsoleChannelDispatchCommand,
                 playingGameName,
                 toMinecraftFormat
         );

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeListener.java
@@ -58,7 +58,8 @@ public class BungeeListener implements Listener {
 
         MarkComponent[] components = MarkdownConverter.fromMinecraftMessage(message, '&');
         String convertedMessage = MarkdownConverter.toDiscordMessage(components);
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 toDiscordFormat.replace("{server}", server.getInfo().getName())
                         .replace("{sender}", sender.getDisplayName())
                         .replace("{message}", convertedMessage)
@@ -67,7 +68,8 @@ public class BungeeListener implements Listener {
 
     @EventHandler
     public void onLogin(LoginEvent e) {
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 Message.userActivity.toString(),
                 null,
                 Message.joined.toString().replace("{name}", e.getConnection().getName()),
@@ -90,7 +92,8 @@ public class BungeeListener implements Listener {
 
     @EventHandler
     public void onLogout(PlayerDisconnectEvent e) {
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 Message.userActivity.toString(),
                 null,
                 Message.left.toString().replace("{name}", e.getPlayer().getName()),
@@ -115,7 +118,8 @@ public class BungeeListener implements Listener {
     public void onSwitch(ServerSwitchEvent e) {
         if (hiddenServers.contains(e.getPlayer().getServer().getInfo().getName())) return;
 
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 Message.userActivity.toString(),
                 null,
                 Message.serverSwitched.toString()

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeLoggingListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/BungeeLoggingListener.java
@@ -1,0 +1,60 @@
+package work.novablog.mcplugin.discordconnect.listener;
+
+import com.gmail.necnionch.myapp.markdownconverter.MarkComponent;
+import com.gmail.necnionch.myapp.markdownconverter.MarkdownConverter;
+import org.jetbrains.annotations.NotNull;
+import work.novablog.mcplugin.discordconnect.util.BotManager;
+
+import java.text.SimpleDateFormat;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * BungeeCordのコンソールログをDiscordに送信するためのリスナー
+ */
+public class BungeeLoggingListener extends Handler {
+    private final BotManager botManager;
+
+    public BungeeLoggingListener(@NotNull BotManager botManager, @NotNull String logFormat) {
+        this.botManager = botManager;
+        setLevel(Level.INFO);
+        setFormatter(new LogFormatter(logFormat));
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        if (!isLoggable(record)) return;
+        botManager.sendMessageToChannel(BotManager.ChannelType.CONSOLE, getFormatter().format(record));
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+    }
+
+    private static class LogFormatter extends Formatter {
+        private final SimpleDateFormat sdf;
+        private final String format;
+
+        public LogFormatter(@NotNull String format) {
+            sdf = new SimpleDateFormat("HH:mm:ss");
+            this.format = format;
+        }
+
+        @Override
+        public String format(LogRecord record) {
+            MarkComponent[] components = MarkdownConverter.fromMinecraftMessage(formatMessage(record), '§');
+            String convertedMessage = MarkdownConverter.toDiscordMessage(components);
+
+            return format.replace("{time}", sdf.format(record.getMillis()))
+                    .replace("{level}", record.getLevel().getLocalizedName())
+                    .replace("{logger}", record.getLoggerName())
+                    .replace("{message}", convertedMessage);
+        }
+    }
+}

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/ChatCasterListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/ChatCasterListener.java
@@ -37,6 +37,6 @@ public class ChatCasterListener implements Listener {
         String message = api.formatMessageForDiscord(event);
         MarkComponent[] components = MarkdownConverter.fromMinecraftMessage(message, '&');
         String output = MarkdownConverter.toDiscordMessage(components);
-        botManager.sendMessageToChatChannel(output);
+        botManager.sendMessageToChannel(BotManager.ChannelType.CHAT, output);
     }
 }

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/DiscordListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/DiscordListener.java
@@ -9,21 +9,49 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.jetbrains.annotations.NotNull;
+import work.novablog.mcplugin.discordconnect.util.Message;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 public class DiscordListener extends ListenerAdapter {
+    private final Logger logger;
     private final List<Long> chatChannelIds;
+    private final List<Long> dispatchCommandChannelIds;
     private final String toMinecraftFormat;
 
-    public DiscordListener(@NotNull List<Long> chatChannelIds, @NotNull String toMinecraftFormat) {
+    public DiscordListener(
+            @NotNull Logger logger,
+            @NotNull List<Long> chatChannelIds,
+            @NotNull List<Long> dispatchCommandChannelIds,
+            @NotNull String toMinecraftFormat
+    ) {
+        this.logger = logger;
         this.chatChannelIds = chatChannelIds;
+        this.dispatchCommandChannelIds = dispatchCommandChannelIds;
         this.toMinecraftFormat = toMinecraftFormat;
     }
 
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
+
+        if (dispatchCommandChannelIds.contains(event.getChannel().getIdLong())) {
+            // BungeeCordでコマンド実行
+            logger.info(
+                    Message.dispatchCommand.toString()
+                            .replace("{sender}", event.getAuthor().getName())
+                            .replace("{command}", event.getMessage().getContentRaw())
+            );
+
+            ProxyServer.getInstance().getPluginManager().dispatchCommand(
+                    ProxyServer.getInstance().getConsole(),
+                    event.getMessage().getContentRaw()
+            );
+
+            return;
+        }
+
         if (!chatChannelIds.contains(event.getChannel().getIdLong()))
             return;
 

--- a/src/main/java/work/novablog/mcplugin/discordconnect/listener/LunaChatListener.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/listener/LunaChatListener.java
@@ -32,7 +32,8 @@ public class LunaChatListener implements Listener {
         MarkComponent[] components = MarkdownConverter.fromMinecraftMessage(event.getMessage(), '§');
         String convertedMessage = MarkdownConverter.toDiscordMessage(components);
 
-        botManager.sendMessageToChatChannel(
+        botManager.sendMessageToChannel(
+                BotManager.ChannelType.CHAT,
                 toDiscordFormat.replace("{server}", event.getMember().getServerName())
                         .replace("{sender}", event.getMember().getDisplayName())
                         .replace("{message}", convertedMessage)

--- a/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
@@ -18,6 +18,7 @@ import work.novablog.mcplugin.discordconnect.listener.DiscordListener;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,8 +29,8 @@ import java.util.logging.Logger;
 public class BotManager implements EventListener {
     private final Logger logger;
     private JDA bot;
-    private final List<Long> chatChannelIds;
-    private final List<DiscordSender> chatChannelSenders;
+    private final HashMap<ChannelType, List<Long>> channelIds;
+    private final HashMap<ChannelType, List<DiscordSender>> channelSenders;
     private final String playingGameName;
 
     private boolean isActive;
@@ -55,8 +56,10 @@ public class BotManager implements EventListener {
             isActive = false;
         }
 
-        this.chatChannelIds = chatChannelIds;
-        this.chatChannelSenders = new ArrayList<>();
+        this.channelIds = new HashMap<>();
+        this.channelIds.put(ChannelType.CHAT, chatChannelIds);
+        this.channelSenders = new HashMap<>();
+        this.channelSenders.put(ChannelType.CHAT, new ArrayList<>());
         this.playingGameName = playingGameName;
     }
 
@@ -70,7 +73,8 @@ public class BotManager implements EventListener {
         logger.info(Message.normalShutdown.toString());
 
         //プロキシ停止メッセージ
-        sendMessageToChatChannel(
+        sendMessageToChannel(
+                ChannelType.CHAT,
                 Message.serverActivity.toString(),
                 null,
                 Message.proxyStopped.toString(),
@@ -86,20 +90,22 @@ public class BotManager implements EventListener {
         );
 
         //送信完了まで待機
-        chatChannelSenders.forEach(DiscordSender::interrupt);
-        chatChannelSenders.forEach(sender -> {
-            try {
-                sender.join();
-            } catch (InterruptedException e) {
-                logger.log(Level.SEVERE, "Exception", e);
-            }
-        });
+        for (List<DiscordSender> senders : channelSenders.values()) {
+            senders.forEach(DiscordSender::interrupt);
+            senders.forEach(sender -> {
+                try {
+                    sender.join();
+                } catch (InterruptedException e) {
+                    logger.log(Level.SEVERE, "Exception", e);
+                }
+            });
+        }
 
         //botのシャットダウン
         bot.shutdown();
 
         bot = null;
-        chatChannelSenders.clear();
+        channelSenders.clear();
         isActive = false;
     }
 
@@ -108,18 +114,23 @@ public class BotManager implements EventListener {
         if (event instanceof ReadyEvent) {
             //Botのログインが完了
 
-            //チャットチャンネルを登録
-            for (long id : chatChannelIds) {
-                TextChannel channel = bot.getTextChannelById(id);
+            //channelSendersの設定
+            for (ChannelType type : channelIds.keySet()) {
+                List<Long> channelIds = this.channelIds.get(type);
+                List<DiscordSender> senders = channelSenders.get(type);
 
-                if (channel == null) {
-                    logger.warning(Message.channelNotFound.toString().replace("{id}", String.valueOf(id)));
-                    continue;
+                for (long channelId : channelIds) {
+                    TextChannel channel = bot.getTextChannelById(channelId);
+
+                    if (channel == null) {
+                        logger.warning(Message.channelNotFound.toString().replace("{id}", String.valueOf(channelId)));
+                        continue;
+                    }
+
+                    DiscordSender sender = new DiscordSender(channel);
+                    sender.start();
+                    senders.add(sender);
                 }
-
-                DiscordSender sender = new DiscordSender(channel);
-                sender.start();
-                chatChannelSenders.add(sender);
             }
 
             updateGameName(
@@ -129,7 +140,8 @@ public class BotManager implements EventListener {
 
             logger.info(Message.botIsReady.toString());
 
-            sendMessageToChatChannel(
+            sendMessageToChannel(
+                    ChannelType.CHAT,
                     Message.serverActivity.toString(),
                     null,
                     Message.proxyStarted.toString(),
@@ -147,17 +159,19 @@ public class BotManager implements EventListener {
     }
 
     /**
-     * チャットチャンネルへメッセージを送信
+     * テキストチャンネルへメッセージを送信
      *
-     * @param mes メッセージ
+     * @param channelType チャンネルの種類
+     * @param mes         メッセージ
      */
-    public void sendMessageToChatChannel(@NotNull String mes) {
-        chatChannelSenders.forEach(sender -> sender.addQueue(mes));
+    public void sendMessageToChannel(@NotNull ChannelType channelType, @NotNull String mes) {
+        channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(mes));
     }
 
     /**
-     * チャットチャンネルへ埋め込みメッセージを送信
+     * テキストチャンネルへ埋め込みメッセージを送信
      *
+     * @param channelType チャンネルの種類
      * @param title       タイトル
      * @param titleUrl    タイトルのリンクURL
      * @param desc        説明
@@ -171,7 +185,8 @@ public class BotManager implements EventListener {
      * @param image       画像
      * @param thumbnail   サムネイル
      */
-    public void sendMessageToChatChannel(
+    public void sendMessageToChannel(
+            @NotNull ChannelType channelType,
             @Nullable String title,
             @Nullable String titleUrl,
             @Nullable String desc,
@@ -196,7 +211,7 @@ public class BotManager implements EventListener {
         eb.setImage(image);
         eb.setThumbnail(thumbnail);
 
-        chatChannelSenders.forEach(sender -> sender.addQueue(eb.build()));
+        channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(eb.build()));
     }
 
     /**
@@ -214,5 +229,9 @@ public class BotManager implements EventListener {
                 Activity.playing(playingGameName
                         .replace("{players}", String.valueOf(playerCount))
                         .replace("{max}", maxPlayersString)));
+    }
+
+    public enum ChannelType {
+        CHAT
     }
 }

--- a/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
@@ -125,14 +125,14 @@ public class BotManager implements EventListener {
 
             //channelSendersの設定
             for (ChannelType type : channelIds.keySet()) {
-                List<Long> channelIds = this.channelIds.get(type);
+                List<Long> ids = this.channelIds.get(type);
                 List<DiscordSender> senders = channelSenders.get(type);
 
-                for (long channelId : channelIds) {
-                    TextChannel channel = bot.getTextChannelById(channelId);
+                for (long id : ids) {
+                    TextChannel channel = bot.getTextChannelById(id);
 
                     if (channel == null) {
-                        logger.warning(Message.channelNotFound.toString().replace("{id}", String.valueOf(channelId)));
+                        logger.warning(Message.channelNotFound.toString().replace("{id}", String.valueOf(id)));
                         continue;
                     }
 

--- a/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
@@ -39,6 +39,7 @@ public class BotManager implements EventListener {
             @NotNull Logger logger,
             @NotNull String token,
             @NotNull List<Long> chatChannelIds,
+            @NotNull List<Long> consoleChannelIds,
             @NotNull String playingGameName,
             @NotNull String toMinecraftFormat
     ) {
@@ -59,7 +60,9 @@ public class BotManager implements EventListener {
         this.channelIds = new HashMap<>();
         this.channelIds.put(ChannelType.CHAT, chatChannelIds);
         this.channelSenders = new HashMap<>();
+        this.channelIds.put(ChannelType.CONSOLE, consoleChannelIds);
         this.channelSenders.put(ChannelType.CHAT, new ArrayList<>());
+        this.channelSenders.put(ChannelType.CONSOLE, new ArrayList<>());
         this.playingGameName = playingGameName;
     }
 
@@ -74,7 +77,7 @@ public class BotManager implements EventListener {
 
         //プロキシ停止メッセージ
         sendMessageToChannel(
-                ChannelType.CHAT,
+                ChannelType.ALL,
                 Message.serverActivity.toString(),
                 null,
                 Message.proxyStopped.toString(),
@@ -138,10 +141,8 @@ public class BotManager implements EventListener {
                     ProxyServer.getInstance().getConfig().getPlayerLimit()
             );
 
-            logger.info(Message.botIsReady.toString());
-
             sendMessageToChannel(
-                    ChannelType.CHAT,
+                    ChannelType.ALL,
                     Message.serverActivity.toString(),
                     null,
                     Message.proxyStarted.toString(),
@@ -155,6 +156,8 @@ public class BotManager implements EventListener {
                     null,
                     null
             );
+
+            logger.info(Message.botIsReady.toString());
         }
     }
 
@@ -165,7 +168,11 @@ public class BotManager implements EventListener {
      * @param mes         メッセージ
      */
     public void sendMessageToChannel(@NotNull ChannelType channelType, @NotNull String mes) {
-        channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(mes));
+        if (channelType == ChannelType.ALL) {
+            channelSenders.values().forEach(senders -> senders.forEach(sender -> sender.addQueue(mes)));
+        } else {
+            channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(mes));
+        }
     }
 
     /**
@@ -211,7 +218,11 @@ public class BotManager implements EventListener {
         eb.setImage(image);
         eb.setThumbnail(thumbnail);
 
-        channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(eb.build()));
+        if (channelType == ChannelType.ALL) {
+            channelSenders.values().forEach(senders -> senders.forEach(sender -> sender.addQueue(eb.build())));
+        } else {
+            channelSenders.getOrDefault(channelType, new ArrayList<>()).forEach(sender -> sender.addQueue(eb.build()));
+        }
     }
 
     /**
@@ -232,6 +243,6 @@ public class BotManager implements EventListener {
     }
 
     public enum ChannelType {
-        CHAT
+        CHAT, CONSOLE, ALL
     }
 }

--- a/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/util/BotManager.java
@@ -18,6 +18,7 @@ import work.novablog.mcplugin.discordconnect.listener.DiscordListener;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
@@ -40,6 +41,7 @@ public class BotManager implements EventListener {
             @NotNull String token,
             @NotNull List<Long> chatChannelIds,
             @NotNull List<Long> consoleChannelIds,
+            boolean allowConsoleChannelDispatchCommand,
             @NotNull String playingGameName,
             @NotNull String toMinecraftFormat
     ) {
@@ -48,8 +50,12 @@ public class BotManager implements EventListener {
         //ログインする
         try {
             bot = JDABuilder.createLight(token, GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT)
-                    .addEventListeners(this, new DiscordListener(chatChannelIds, toMinecraftFormat))
-                    .build();
+                    .addEventListeners(this, new DiscordListener(
+                            logger,
+                            chatChannelIds,
+                            allowConsoleChannelDispatchCommand ? consoleChannelIds : Collections.emptyList(),
+                            toMinecraftFormat
+                    )).build();
             isActive = true;
         } catch (InvalidTokenException e) {
             this.logger.severe(Message.invalidToken.toString());

--- a/src/main/java/work/novablog/mcplugin/discordconnect/util/Message.java
+++ b/src/main/java/work/novablog/mcplugin/discordconnect/util/Message.java
@@ -20,6 +20,7 @@ public enum Message {
     updateCheckFailed,
     pluginIsLatest,
 
+    dispatchCommand,
     bungeeCommandDenied,
     bungeeCommandNotFound,
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ hiddenServers:
 consoleChannel:
   channelId: -1
   logFormat: "[{time} {level}] {message}"
+  allowDispatchCommand: true
 
 updateCheck: true
 # この値は変更しないでください！ (Don't change the value!)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,10 @@ toDiscordFormat: "*({server})* **{sender}** : {message}"
 hiddenServers:
   - test
 
+consoleChannel:
+  channelId: -1
+  logFormat: "[{time} {level}] {message}"
+
 updateCheck: true
 # この値は変更しないでください！ (Don't change the value!)
 configVersion: 5

--- a/src/main/resources/ja_JP.properties
+++ b/src/main/resources/ja_JP.properties
@@ -9,6 +9,7 @@ updateNotice=アップデートがあります（{current} -> {latest}）
 updateDownloadLink=ダウンロードリンク: {link}
 updateCheckFailed=アップデートの確認に失敗しました
 pluginIsLatest=プラグインは最新バージョンです（{current}）
+dispatchCommand={sender}がコマンドを実行しました: {command}
 bungeeCommandDenied=§cあなたはこのコマンドを実行する権限を持っていません！
 bungeeCommandNotFound=§cコマンドが見つかりません！
 bungeeCommandHelpLine1=§e------ §fDiscordConnectのコマンド一覧 §e------


### PR DESCRIPTION
## config.ymlの変更点
```yaml
consoleChannel:
  channelId: -1
  logFormat: "[{time} {level}] {message}"
  allowDispatchCommand: true
```
`channelId`のチャンネルにBungeeCordコンソールログを`logFormat`の形式で転送する
`allowDispatchCommand`がtrueならチャンネルからBungeeCordのコマンドを実行できるようにする